### PR TITLE
chore(deps): upgrade lodash to version 4.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "jest-diff": "~30.3.0",
     "jest-matcher-utils": "~30.3.0",
-    "lodash": "~4.18.0"
+    "lodash": "~4.18.1"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "~0.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
         specifier: ~30.3.0
         version: 30.3.0
       lodash:
-        specifier: ~4.18.0
+        specifier: ~4.18.1
         version: 4.18.1
     devDependencies:
       '@arethetypeswrong/cli':


### PR DESCRIPTION
Some how 4.18.0 version I cannot see in npm registry: https://www.npmjs.com/package/lodash?activeTab=versions

So upgrading to latest version of lodash.

@NiGhTTraX 🙏 